### PR TITLE
Output channel median normalization factors to a file if necessary

### DIFF
--- a/R/DEqMS.R
+++ b/R/DEqMS.R
@@ -187,13 +187,16 @@ medpolishSummary <- function(dat,group_col=2) {
     return (dat.new)
 }
 
-equalMedianNormalization <- function(dat) {
+equalMedianNormalization <- function(dat, optional_outfile) {
     sizefactor = matrixStats::colMedians(as.matrix(dat),na.rm = TRUE)
     dat.nm = sweep(dat,2,sizefactor)
+    if (!missing(optional_outfile)) {
+      write.table(data.frame(channels=colnames(x), medians=sizefactor), optional_outfile, sep='\t', header=T)
+    }
     return (dat.nm)
 }
 
-medianSweeping <- function(dat,group_col=2) {
+medianSweeping <- function(dat,group_col=2,channelmedian_outfile) {
     dat.ratio = dat
     dat.ratio[,3:ncol(dat)] = dat.ratio[,3:ncol(dat)] - 
         matrixStats::rowMedians(as.matrix(dat.ratio[,3:ncol(dat)]),na.rm = TRUE)
@@ -204,7 +207,7 @@ medianSweeping <- function(dat,group_col=2) {
     dat.new = dat.summary[,-1]
     rownames(dat.new) = dat.summary[,1]
     
-    dat.nm = equalMedianNormalization(dat.new)
+    dat.nm = equalMedianNormalization(dat.new, optional_outfile=channelmedian_outfile)
     return (dat.nm)
 }
 

--- a/R/DEqMS.R
+++ b/R/DEqMS.R
@@ -191,7 +191,7 @@ equalMedianNormalization <- function(dat, optional_outfile) {
     sizefactor = matrixStats::colMedians(as.matrix(dat),na.rm = TRUE)
     dat.nm = sweep(dat,2,sizefactor)
     if (!missing(optional_outfile)) {
-      write.table(data.frame(channels=colnames(x), medians=sizefactor), optional_outfile, sep='\t', header=T)
+      write.table(data.frame(channels=colnames(dat), medians=sizefactor), optional_outfile, sep='\t', header=T)
     }
     return (dat.nm)
 }

--- a/R/DEqMS.R
+++ b/R/DEqMS.R
@@ -191,7 +191,7 @@ equalMedianNormalization <- function(dat, optional_outfile) {
     sizefactor = matrixStats::colMedians(as.matrix(dat),na.rm = TRUE)
     dat.nm = sweep(dat,2,sizefactor)
     if (!missing(optional_outfile)) {
-      write.table(data.frame(channels=colnames(dat), medians=sizefactor), optional_outfile, sep='\t', header=T)
+      write.table(data.frame(channels=colnames(dat), medians=sizefactor), optional_outfile, sep='\t', quote=F)
     }
     return (dat.nm)
 }

--- a/R/DEqMS.R
+++ b/R/DEqMS.R
@@ -191,7 +191,7 @@ equalMedianNormalization <- function(dat, optional_outfile) {
     sizefactor = matrixStats::colMedians(as.matrix(dat),na.rm = TRUE)
     dat.nm = sweep(dat,2,sizefactor)
     if (!missing(optional_outfile)) {
-      write.table(data.frame(channels=colnames(dat), medians=sizefactor), optional_outfile, sep='\t', quote=F)
+      write.table(data.frame(channels=colnames(dat), medians=sizefactor), optional_outfile, sep='\t', quote=F, row.names=F)
     }
     return (dat.nm)
 }


### PR DESCRIPTION
This PR adds the possibility to output a table with normalization factors that are found and used by the `equalMedianNormalization` function.